### PR TITLE
Document usage with a complex query

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ $ docker run --rm --name jq endeveit/docker-jq \
 }
 ```
 
+Test a complex command:
+
+```bash
+$ docker run --rm --name jq endeveit/docker-jq \
+  sh -c 'echo "{\"foo\":\"bar\"}" | jq ". | .foo as \$var | \$var"'
+"bar"
+```
+
 Start an interactive container with jq:
 
 ```


### PR DESCRIPTION
If the query contains spaces and isn't surrounded with quotes,
everything after the space of the first part of the query will
interpreted as a argument for jq or more shell script. For example:

```
sh -c 'echo "{\"foo\":\"bar\"}" | jq .foo as $var | $var'
```

Produces:

```
jq: error: Could not open file as: No such file or directory
```

Double quotes work more nicely than trying to escape single quotes, but
note that they require escaping anything the shell would interpret, such
as variables. For example:

```
sh -c 'echo "{\"foo\":\"bar\"}" | jq ".foo as $var | $var"'
```

Produces:

```
jq: error: syntax error, unexpected '|', expecting '$' or '[' or '{' (Unix shell quoting issues?) at <top-level>, line 1:
.foo as  |
```

Escaping the dollar sign gets us to the desired result, where:

```
sh -c 'echo "{\"foo\":\"bar\"}" | jq ".foo as \$var | \$var"'
```

Outputs:

```
"bar"
```